### PR TITLE
メイン画面とログイン・新規登録ページのリンク設定

### DIFF
--- a/app/views/layouts/layout_for_UserAdmin.haml
+++ b/app/views/layouts/layout_for_UserAdmin.haml
@@ -10,17 +10,17 @@
   %body
   .single-container
     %header.single-header
-      = link_to image_tag("header-logo.svg", alt: "Mercari", class: "single-header-logo"), "https://www.mercari.com/jp/"
+      = link_to image_tag("header-logo.svg", alt: "Mercari", class: "single-header-logo"), root_path
     = yield
     %footer.single-footer
       %nav
         %ul
           %li
-            =link_to "プライバシーポリシー","https://www.google.com", class: ""
+            =link_to "プライバシーポリシー","https://www.google.com", class: "critical_information"
           %li
-            =link_to "メルカリ利用規約","https://www.google.com", class: ""
+            =link_to "メルカリ利用規約","https://www.google.com", class: "critical_information"
           %li
-            =link_to "特定商取引に関する表記","https://www.google.com", class: ""
-      = link_to image_tag("admin_footer_logo.svg", alt: "Mercari", class: "single-footer-logo"), "https://www.mercari.com/jp/"
+            =link_to "特定商取引に関する表記","https://www.google.com", class: "critical_information"
+      = link_to image_tag("admin_footer_logo.svg", alt: "Mercari", class: "single-footer-logo"), root_path
       %p
         %small © 2019 Mercari

--- a/app/views/layouts/layout_for_UserAdmin_SignUp.haml
+++ b/app/views/layouts/layout_for_UserAdmin_SignUp.haml
@@ -4,11 +4,12 @@
     %meta{content:"text/html; charset=UTF-8", "http-equiv": "Content-Type"}/
     %title Freemarket42nagoya
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
   .single-container
     %header.single-header--SignUp
       .single-header--SignUp__SignUpimage
-        = link_to image_tag("header-logo.svg", alt: "Mercari", class: "single-header-logo"), "https://www.mercari.com/jp/", class: "single-header-link"
+        = link_to image_tag("header-logo.svg", alt: "Mercari", class: "single-header-logo"), root_path, class: "single-header-link"
       .single-header--SignUp__SignUpNav
         %nav
           %ol.progress-bar
@@ -32,6 +33,6 @@
             =link_to "メルカリ利用規約","https://www.google.com", class: "critical_information"
           %li
             =link_to "特定商取引に関する表記","https://www.google.com",  class: "critical_information"
-      = link_to image_tag("admin_footer_logo.svg", alt: "Mercari", class: "single-footer-logo"), "https://www.mercari.com/jp/"
+      = link_to image_tag("admin_footer_logo.svg", alt: "Mercari", class: "single-footer-logo"), root_path
       %p
         %small © 2019 Mercari

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -5,9 +5,9 @@
       = link_to image_tag("header-logo.svg", alt: "ヘッダーロゴ", style: "vertical-align:bottom"), root_path, class: "top-header__logo__link"
 
     .top-header__user-nav
-      = link_to "ログイン", "#", class: "sp-header-btn login-btn"
+      = link_to "ログイン", new_user_session_path, class: "sp-header-btn login-btn"
 
-      = link_to "新規会員", "#", class: "sp-header-btn signup-btn"
+      = link_to "新規会員", user_registration_index_path, class: "sp-header-btn signup-btn"
 
   .search-bar
     = form_tag "", class: "search-bar__form" do
@@ -49,7 +49,7 @@
       .right-nav
         %ul.right-nav__buttons
           %li
-            = link_to "ログイン", "#", class: "sp-header-btn login-btn"
+            = link_to "ログイン", new_user_session_path, class: "sp-header-btn login-btn"
 
           %li
-            = link_to "新規会員登録", "#", class: "sp-header-btn pc-signup"
+            = link_to "新規会員登録", user_registration_index_path, class: "sp-header-btn pc-signup"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -128,10 +128,10 @@ ja:
       not_an_integer: は整数で入力してください
       odd: は奇数にしてください
       required: を入力してください
-      taken: はすでに存在します
-      too_long: は%{count}文字以内で入力してください
-      too_short: は%{count}文字以上で入力してください
-      wrong_length: は%{count}文字で入力してください
+      taken: すでに存在します
+      too_long: "%{count}文字以内で入力してください"
+      too_short: "%{count}文字以上で入力してください"
+      wrong_length: "%{count}文字で入力してください"
       other_than: は%{count}以外の値にしてください
     template:
       body: 次の項目を確認してください

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,7 +8,7 @@ describe User do
     it "ニックネームが入力されていないと登録できない" do
       user = build(:user, nickname: nil)
       user.valid?
-      expect(user.errors[:nickname]).to include("を入力してください")
+      expect(user.errors[:nickname]).to include("入力してください")
     end
     it "ニックネームは20文字以内だと登録できる" do
       user = build(:user, nickname: "テスト0000000テスト0000000")
@@ -18,49 +18,49 @@ describe User do
     it "ニックネームは21文字以上だと登録できない" do
       user = build(:user, nickname: "テスト0000000テスト00000001")
       user.valid?
-      expect(user.errors[:nickname][0]).to include("は20文字以内で入力してください")
+      expect(user.errors[:nickname][0]).to include("20文字以内で入力してください")
     end
     it "Eメールが入力されていないと登録できない" do
       user = build(:user, email: nil)
       user.valid?
-      expect(user.errors[:email]).to include("を入力してください")
+      expect(user.errors[:email]).to include("入力してください")
     end
     it "Eメールが2重で登録されていない" do
       user = create(:user)
       another_user = build(:user)
       another_user.valid?
-      expect(another_user.errors[:email]).to include("はすでに存在します")
+      expect(another_user.errors[:email]).to include("すでに存在します")
     end
     it "パスワードが入力されていないと登録できない" do
       user = build(:user, password: nil)
       user.valid?
-      expect(user.errors[:password]).to include("を入力してください")
+      expect(user.errors[:password]).to include("入力してください")
     end
     it "パスワードが存在してもパスワード確認が空では登録できないこと" do
       user = User.new(nickname: "sample", email: "kkk@gmail.com", password: "00000000", password_confirmation: "")
       user.valid?
-      expect(user.errors[:password_confirmation]).to include("とPasswordの入力が一致しません")
+      expect(user.errors[:password_confirmation]).to include("入力が一致しません")
     end
     it "携帯電話が入力されていないと登録できない" do
       user = build(:user, phone_number: nil)
       user.valid?
-      expect(user.errors[:phone_number]).to include("を入力してください")
+      expect(user.errors[:phone_number]).to include("入力してください")
     end
     it "携帯電話の形式でないと登録できない" do
       user = build(:user, phone_number: "0000000000")
       user.valid?
-      expect(user.errors[:phone_number]).to include("は不正な値です")
+      expect(user.errors[:phone_number]).to include("不正な値です")
     end
     it "携帯電話が2重で登録されていない" do
       user = create(:user)
       another_user = build(:user)
       another_user.valid?
-      expect(another_user.errors[:phone_number]).to include("はすでに存在します")
+      expect(another_user.errors[:phone_number]).to include("すでに存在します")
     end
     it "名字が入力されていないと登録できない" do
       user = build(:user, lastname: nil)
       user.valid?
-      expect(user.errors[:lastname]).to include("を入力してください")
+      expect(user.errors[:lastname]).to include("入力してください")
     end
     it "名字は20文字以内だと登録できる" do
       user = build(:user, lastname: "テスト0000000テスト0000000")
@@ -70,12 +70,12 @@ describe User do
     it "名字は21文字以上だと登録できない" do
       user = build(:user, lastname: "テスト0000000テスト00000001")
       user.valid?
-      expect(user.errors[:lastname][0]).to include("は20文字以内で入力してください")
+      expect(user.errors[:lastname][0]).to include("20文字以内で入力してください")
     end
     it "名前が入力されていないと登録できない" do
       user = build(:user, firstname: nil)
       user.valid?
-      expect(user.errors[:firstname]).to include("を入力してください")
+      expect(user.errors[:firstname]).to include("入力してください")
     end
     it "名前は20文字以内だと登録できる" do
       user = build(:user, firstname: "テスト0000000テスト0000000")
@@ -85,12 +85,12 @@ describe User do
     it "名前は21文字以上だと登録できない" do
       user = build(:user, firstname: "テスト0000000テスト00000001")
       user.valid?
-      expect(user.errors[:firstname][0]).to include("は20文字以内で入力してください")
+      expect(user.errors[:firstname][0]).to include("20文字以内で入力してください")
     end
     it "名字カナが入力されていないと登録できない" do
       user = build(:user, lastname_kana: nil)
       user.valid?
-      expect(user.errors[:lastname_kana]).to include("を入力してください")
+      expect(user.errors[:lastname_kana]).to include("入力してください")
     end
     it "名字カナは20文字以内だと登録できる" do
       user = build(:user, lastname_kana: "テスト0000000テスト0000000")
@@ -100,12 +100,12 @@ describe User do
     it "名字カナは21文字以上だと登録できない" do
       user = build(:user, lastname_kana: "テスト0000000テスト00000001")
       user.valid?
-      expect(user.errors[:lastname_kana][0]).to include("は20文字以内で入力してください")
+      expect(user.errors[:lastname_kana][0]).to include("20文字以内で入力してください")
     end
     it "名前カナが入力されていないと登録できない" do
       user = build(:user, firstname_kana: nil)
       user.valid?
-      expect(user.errors[:firstname_kana]).to include("を入力してください")
+      expect(user.errors[:firstname_kana]).to include("入力してください")
     end
     it "名前カナは20文字以内だと登録できる" do
       user = build(:user, firstname_kana: "テスト0000000テスト0000000")
@@ -115,37 +115,37 @@ describe User do
     it "名前カナは21文字以上だと登録できない" do
       user = build(:user, firstname_kana: "テスト0000000テスト00000001")
       user.valid?
-      expect(user.errors[:firstname_kana][0]).to include("は20文字以内で入力してください")
+      expect(user.errors[:firstname_kana][0]).to include("20文字以内で入力してください")
     end
     it "郵便番号が入力されていないと登録できない" do
       user = build(:user, postalcode: nil)
       user.valid?
-      expect(user.errors[:postalcode]).to include("を入力してください")
+      expect(user.errors[:postalcode]).to include("入力してください")
     end
     it "郵便番号の形式があっていないと登録できない" do
       user = build(:user, postalcode: "00000000")
       user.valid?
-      expect(user.errors[:postalcode]).to include("は不正な値です")
+      expect(user.errors[:postalcode]).to include("不正な値です")
     end
     it "都道府県が入力されていないと登録できない" do
       user = build(:user, prefecture: nil)
       user.valid?
-      expect(user.errors[:prefecture]).to include("を入力してください")
+      expect(user.errors[:prefecture]).to include("入力してください")
     end
     it "市区町村が入力されていないと登録できない" do
       user = build(:user, city: nil)
       user.valid?
-      expect(user.errors[:city]).to include("を入力してください")
+      expect(user.errors[:city]).to include("入力してください")
     end
     it "番地が入力されていないと登録できない" do
       user = build(:user, block: nil)
       user.valid?
-      expect(user.errors[:block]).to include("を入力してください")
+      expect(user.errors[:block]).to include("入力してください")
     end
     it "支払い方法が入力されていないと登録できない" do
       user = build(:user, payment: nil)
       user.valid?
-      expect(user.errors[:payment]).to include("を入力してください")
+      expect(user.errors[:payment]).to include("入力してください")
     end
   end
 end


### PR DESCRIPTION
# 【概要】
・メイン画面とログイン・新規登録ページのリンク設定

# 【理由】
・ユーザーはメイン画面から新規登録またはログインし、商品購入ができるようになる