### PR TITLE
【フロントエンド】トップページ　ドロップダウンメニュー

### DIFF
--- a/app/assets/stylesheets/_mixin.scss
+++ b/app/assets/stylesheets/_mixin.scss
@@ -78,3 +78,37 @@ $breakpoints: (
   font-size:$font-size;
   font-weight: normal;
 }
+
+@mixin dropdown-menu {
+  display: block;
+  padding: 0 16px;
+  line-height: 44px;
+  font-size: 14px;
+  color: $char-black;
+  &:hover {
+    color: $shiro;
+    background-color: $main-red;
+  }
+}
+
+@mixin child-dropdown-menu ($width: 224px){
+  position: absolute;
+  top: 0;
+  left: 224px;
+  bottom: 0;
+  background-color: $shiro;
+  box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.24);
+  & > li {
+    width: $width;
+  }
+  & > li > a {
+    color: $char-black;
+    font-size: 14px;
+    display: block;
+    position: relative;
+    padding: 2.5px 16px;
+    &:hover {
+      background-color: rgba(0,0,0,0.12);
+    }
+  }
+}

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -200,7 +200,6 @@
   }
 }
 
-
 // PC・タブレット用ヘッダー
 .pc-header {
   position: relative;
@@ -278,41 +277,6 @@ input[type="text"]:focus {
 .bottom-wrapper {
   @include clearfix();
   margin: 8px 0 0;
-
-  .left-nav {
-    float: left;
-
-    &__menu li {
-      display: inline-block;
-      position: relative;
-    }
-
-    &__menu {
-      &--category {
-        color: $char-black;
-        font-size: 14px;
-        line-height: 38px;
-        display: block;
-      }
-
-      &--category:hover {
-        color: $main-blue;
-      }
-
-      &--brand {
-        color: $char-black;
-        font-size: 14px;
-        line-height: 38px;
-        padding-left: 16px;
-        display: block;
-      }
-
-      &--brand:hover {
-        color: $main-blue;
-      }
-    }
-  }
-
   .right-nav {
     float: right;
 
@@ -354,3 +318,77 @@ input[type="text"]:focus {
   }
 }
 
+// カテゴリー・ブランド ドロップダウンメニュー
+.left-nav {
+  float: left;
+
+  &__menu {
+    & > li {
+      position: relative;
+      display: inline-block;
+      padding: 0 0 0 16px;
+      vertical-align: center;
+    }
+    & li:first-child {
+      padding: 0;
+    }
+
+    & > li > a {
+      color: $char-black;
+      font-size: 14px;
+      display: block;
+      position: relative;
+      height: 38px;
+      line-height: 32px;
+      &:hover {
+        color: $main-blue;
+      }
+    }
+
+    & > li > ul {
+      @include media(l) {
+        left: 0
+      }
+      width: auto;
+      position: absolute;
+      top: 38px;
+      left: -34px;
+      z-index: 1000;
+      background-color: $shiro;
+      box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.24);
+    }
+
+    &--root-category > li {
+      width: 224px;
+    }
+
+    &--root-category > li > a {
+      @include dropdown-menu();
+    }
+
+    .child-category {
+      @include child-dropdown-menu();
+    }
+
+    .grandchild-category {
+      @include child-dropdown-menu(320px);
+    }
+
+    .pickup-brand {
+      & > li {
+        width: 224px;
+      }
+      & > li > a {
+        @include dropdown-menu();
+      }
+    }
+  }
+}
+
+// カーソルがhoverした時にメニューを表示させる
+ul ul {
+  display: none;
+}
+ul li:hover > ul {
+  display: block;
+}

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -40,12 +40,34 @@
       %nav.left-nav
         %ul.left-nav__menu
           %li
-            %h2
-              = link_to "カテゴリーから探す", "#", class: "left-nav__menu--category"
+            = link_to "カテゴリから探す", "#", class: "left-nav__menu--category"
+            %ul.left-nav__menu--root-category
+              - Category.roots.each do |root|
+                %li
+                  = link_to "#{root.name}", "#"
+                  %ul.child-category
+                    - Category.children_of(root).each do |child|
+                      %li
+                        = link_to "#{child.name}", "#"
+                        %ul.grandchild-category
+                          - Category.children_of(child).each do |grandchild|
+                            %li
+                              = link_to "#{grandchild.name}", "#"
           %li
-            %h2
-              =link_to "ブランドから探す", "#", class: "left-nav__menu--brand"
-
+            = link_to "ブランドから探す", "#", class: "left-nav__menu--brand"
+            %ul.pickup-brand
+              %li
+                = link_to "シャネル", "#"
+              %li
+                = link_to "ナイキ", "#"
+              %li
+                = link_to "ルイ ヴィトン", "#"
+              %li
+                = link_to "シュプリーム", "#"
+              %li
+                = link_to "アディダス", "#"
+              %li
+                = link_to "ブランド一覧", "#"
 
       .right-nav
         %ul.right-nav__buttons


### PR DESCRIPTION
## What
トップページのカテゴリー・ブランドを表示するドロップダウンメニューの実装

## Why
省スペースでカテゴリー・ブランドを表示させるため

## ドロップダウンメニューの挙動
https://gyazo.com/8bac59e28ac163a12179336aee98bffd

## 保留にしているところ
カテゴリーhover時のCSSを階層ごとに保持させるところ