### PR TITLE
【細かな修正を行いました】

### DIFF
--- a/app/assets/stylesheets/_mixin.scss
+++ b/app/assets/stylesheets/_mixin.scss
@@ -169,3 +169,15 @@ $breakpoints: (
     }
   }
 }
+
+// 出品中・売却済のラベルのスタイル
+@mixin item-status-label($label-color: $main-blue) {
+  display: inline-block;
+  padding: 0 5px;
+  background-color: $label-color;
+  font-size: 12px;
+  font-weight: bold;
+  color: $shiro;
+  line-height: 1.5;
+  border-radius: 2px;
+}

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -60,7 +60,6 @@
     }
     & > a:first-child {
       margin-right: 10px;
-      padding-top: 5px;
     }
   }
 }
@@ -301,6 +300,11 @@ input[type="text"]:focus {
         vertical-align: center;
       }
 
+      & > li > a {
+        height: 40px;
+        line-height: 40px;
+      }
+
       & > li > ul {
         @include media(l) {
         }
@@ -327,16 +331,24 @@ input[type="text"]:focus {
         @include mypage-user-icon();
       }
 
-      & .sp-header-btn {
-        margin: 0;
+      & .pc-header-btn {
+        @include media(s) {
+          padding: 0 10px;
+          line-height: 30px;
+        }
+        display: inline-block;
+        padding: 0 6px;
+        border-radius: 4px;
+        text-align: center;
+        line-height: 26px;
       }
 
       & .login-btn {
         display: block;
         border-radius: 7px;
         font-size: 14px;
-        margin-right: 11px;
-        line-height: 30px;
+        height: 32px;
+        line-height: 32px;
         padding: 0 10px;
       }
 
@@ -350,7 +362,8 @@ input[type="text"]:focus {
         display: block;
         border-radius: 7px;
         font-size: 12px;
-        line-height: 30px;
+        height: 32px;
+        line-height: 32px;
         padding: 0 10px;
       }
 
@@ -381,8 +394,8 @@ input[type="text"]:focus {
       font-size: 14px;
       display: block;
       position: relative;
-      height: 38px;
-      line-height: 38px;
+      height: 40px;
+      line-height: 40px;
       &:hover {
         color: $main-blue;
       }

--- a/app/assets/stylesheets/user_listings.scss
+++ b/app/assets/stylesheets/user_listings.scss
@@ -15,7 +15,7 @@
   margin: 0;
   & > li {
     margin: 0;
-    width: 32.5%;
+    width: 32.8%;
     display: inline-block;
     text-align: center;
     & > h3 > a {
@@ -62,13 +62,10 @@
   }
 }
 
-.status-label {
-  display: inline-block;
-  padding: 0 5px;
-  background-color: $main-blue;
-  font-size: 12px;
-  font-weight: bold;
-  color: $shiro;
-  line-height: 1.5;
-  border-radius: 2px;
+.status-label--exhibit {
+  @include item-status-label();
+}
+
+.status-label--sold {
+  @include item-status-label($main-red);
 }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -56,8 +56,8 @@ class ItemsController < ApplicationController
         @item = Item.new(session[:final_params])
         session[:final_params] = nil
         if @item.save
-          flash[:notice_exhibition_completed] = ""
-          redirect_to root_path
+          flash.now[:notice_exhibition_completed] = "出品が完了しました"
+          render :index
         else
           render :new
         end
@@ -116,7 +116,7 @@ class ItemsController < ApplicationController
         session[:final_params] = nil
         if @item.user.id == current_user.id
           if @item.update(final_params)
-            flash[:notice_updated] = ""
+            flash.now[:notice_updated] = "商品の情報を更新しました"
             render "items/myitem-detail"
           else
             render "items/edit"
@@ -135,8 +135,8 @@ class ItemsController < ApplicationController
 
   def destroy
     @item.destroy if @item.user_id == current_user.id
-    flash[:notice_deleted] = ""
-    redirect_to action: :index, locals: {user: current_user }
+      flash.now[:notice_deleted] = "商品を削除しました"
+      render "users/listing", locals: {user: current_user }
   end
 
   private

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -11,7 +11,7 @@
         = f.label :image, class: "item-label" do
           出品画像
           %span.required 必須
-          %p 最大10枚までアップロードできます
+          %p 画像をアップロードしてください。
         = f.file_field :image, class: "sell-dropbox-container"
 
       .sell-content

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,22 +1,7 @@
 / ヘッダー
 = render "shared/header"
 
-- if flash.present?
-  :javascript
-    toastr.options = {
-      "progressBar": true,
-      "positionClass": "toast-top-full-width",
-      "onclick": null,
-      "showDuration": "300",
-      "hideDuration": "1000",
-      "timeOut": "5000",
-      "extendedTimeOut": "1000",
-      "showEasing": "swing",
-      "hideEasing": "linear",
-      "showMethod": "fadeIn",
-      "hideMethod": "fadeOut"
-    }
-    toastr.success("あなたが出品した商品は「出品した商品一覧」からいつでも見ることができます。", "出品が完了しました")
+= render "shared/flash_exhibition_completed"
 
 / スライド
 %ul.bxslider

--- a/app/views/items/myitem-detail.html.haml
+++ b/app/views/items/myitem-detail.html.haml
@@ -1,21 +1,6 @@
 = render "shared/header"
 
-- if flash.present?
-  :javascript
-    toastr.options = {
-      "progressBar": true,
-      "positionClass": "toast-top-full-width",
-      "onclick": null,
-      "showDuration": "300",
-      "hideDuration": "1000",
-      "timeOut": "5000",
-      "extendedTimeOut": "1000",
-      "showEasing": "swing",
-      "hideEasing": "linear",
-      "showMethod": "fadeIn",
-      "hideMethod": "fadeOut"
-    }
-    toastr.success("商品の情報を更新しました。")
+= render "shared/flash_updated"
 
 .main-container
   .mypage-container

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -12,7 +12,7 @@
         = f.label :image, class: "item-label" do
           出品画像
           %span.required 必須
-          %p 最大10枚までアップロードできます
+          %p 画像をアップロードしてください。
         = f.file_field :image, class: "sell-dropbox-container"
 
       .sell-content

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -32,15 +32,15 @@
                 %tr
                   %th カテゴリー
                   %td
-                    =link_to @item.category.ancestors[0].name, "#"
+                    =link_to @item.category.ancestors[0].name, "#" if @item.category.ancestors[0].present?
                     %br
-                    =link_to @item.category.ancestors[1].name, "#"
+                    =link_to @item.category.ancestors[1].name, "#" if @item.category.ancestors[1].present?
                     %br
                     =link_to @item.category.name, "#"
                 %tr
                   %th ブランド
                   %td
-                    =link_to @item.brand.name, "#"
+                    =link_to @item.brand.name, "#" if @item.brand.present?
                 %tr
                   %th 商品のサイズ
                   %td
@@ -95,11 +95,11 @@
               %tr
                 %th カテゴリー
                 %td
-                  =link_to @item.category.ancestors[0].name, "#"
+                  =link_to @item.category.ancestors[0].name, "#" if @item.category.ancestors[0].present?
                   %br
-                  =link_to @item.category.ancestors[1].name, "#"
+                  =link_to @item.category.ancestors[1].name, "#" if @item.category.ancestors[1].present?
                   %br
-                  =link_to @item.category.name, "#"
+                  =link_to @item.category.name, "#" if @item.brand.present?
               %tr
                 %th ブランド
                 %td ナノ ユニバース

--- a/app/views/shared/_flash_deleted.html.haml
+++ b/app/views/shared/_flash_deleted.html.haml
@@ -1,0 +1,16 @@
+- if flash[:notice_deleted]
+  :javascript
+    toastr.options = {
+      "progressBar": true,
+      "positionClass": "toast-top-full-width",
+      "onclick": null,
+      "showDuration": "300",
+      "hideDuration": "1000",
+      "timeOut": "5000",
+      "extendedTimeOut": "1000",
+      "showEasing": "swing",
+      "hideEasing": "linear",
+      "showMethod": "fadeIn",
+      "hideMethod": "fadeOut"
+    }
+    toastr.info("商品を削除しました。")

--- a/app/views/shared/_flash_exhibition_completed.html.haml
+++ b/app/views/shared/_flash_exhibition_completed.html.haml
@@ -1,0 +1,16 @@
+- if flash[:notice_exhibition_completed]
+  :javascript
+    toastr.options = {
+      "progressBar": true,
+      "positionClass": "toast-top-full-width",
+      "onclick": null,
+      "showDuration": "300",
+      "hideDuration": "1000",
+      "timeOut": "5000",
+      "extendedTimeOut": "1000",
+      "showEasing": "swing",
+      "hideEasing": "linear",
+      "showMethod": "fadeIn",
+      "hideMethod": "fadeOut"
+    };
+    toastr.success("あなたが出品した商品は「出品した商品一覧」からいつでも見ることができます。", "出品が完了しました")

--- a/app/views/shared/_flash_updated.html.haml
+++ b/app/views/shared/_flash_updated.html.haml
@@ -1,0 +1,16 @@
+- if flash[:notice_updated]
+  :javascript
+    toastr.options = {
+      "progressBar": true,
+      "positionClass": "toast-top-full-width",
+      "onclick": null,
+      "showDuration": "300",
+      "hideDuration": "1000",
+      "timeOut": "5000",
+      "extendedTimeOut": "1000",
+      "showEasing": "swing",
+      "hideEasing": "linear",
+      "showMethod": "fadeIn",
+      "hideMethod": "fadeOut"
+    }
+    toastr.success("商品の情報を更新しました。")

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -99,7 +99,7 @@
               = link_to "ログアウト", destroy_user_session_path, class: "logout-btn", method: :delete
           -else
             %li
-              = link_to "ログイン", new_user_session_path, class: "sp-header-btn login-btn"
+              = link_to "ログイン", new_user_session_path, class: "pc-header-btn login-btn"
 
             %li
-              = link_to "新規会員登録", user_registration_index_path, class: "sp-header-btn pc-signup"
+              = link_to "新規会員登録", user_registration_index_path, class: "pc-header-btn pc-signup"

--- a/app/views/shared/_soldout-items.html.haml
+++ b/app/views/shared/_soldout-items.html.haml
@@ -1,4 +1,4 @@
--if item[:order_status] == "出品中"
+-if item[:order_status] == "売却済"
   %ul.mypage-item-list
     %li.mypage-item
       = link_to controller: "items", action: "edit", name: "myitem-detail", item_id: item.id do
@@ -8,4 +8,4 @@
           .mypage-item__body
             .mypage-item__body__text=item.name
             .mypage-item__body__status
-              .status-label--exhibit 出品中
+              .status-label--sold 売却済

--- a/app/views/users/completed.html.haml
+++ b/app/views/users/completed.html.haml
@@ -15,8 +15,11 @@
           %li.active
             %h3
               =link_to "売却済み", {controller: "users", action: "edit", name: "completed"}
-        %ul
-          %li.mypage-item-not-found 売却済みの商品がありません
+        - if user.items.present? && user.items.map {|item| item[:order_status] == "売却済"}.any?
+          = render partial: "shared/soldout-items", collection: user.items, as: "item"
+        - else
+          %ul
+            %li.mypage-item-not-found 売却済みの商品がありません
 
 
     = render 'shared/side-bar'

--- a/app/views/users/listing.html.haml
+++ b/app/views/users/listing.html.haml
@@ -1,21 +1,6 @@
 = render "shared/header"
 
-- if flash.present?
-  :javascript
-    toastr.options = {
-      "progressBar": true,
-      "positionClass": "toast-top-full-width",
-      "onclick": null,
-      "showDuration": "300",
-      "hideDuration": "1000",
-      "timeOut": "5000",
-      "extendedTimeOut": "1000",
-      "showEasing": "swing",
-      "hideEasing": "linear",
-      "showMethod": "fadeIn",
-      "hideMethod": "fadeOut"
-    }
-    toastr.info("商品を削除しました。")
+= render "shared/flash_deleted"
 
 .main-container
   .mypage-container
@@ -32,7 +17,7 @@
           %li
             %h3
               =link_to "売却済み", {controller: "users", action: "edit", name: "completed"}
-        - if user.items.present?
+        - if user.items.present? && user.items.map {|item| item[:order_status] == "出品中"}.any?
           = render partial: "shared/mypage-items", collection: user.items, as: "item"
         - else
           %ul


### PR DESCRIPTION
## 修正点
* フラッシュメッセージをパーシャル化しました。
→javascriptの変数がうまく部分テンプレートに渡せなかったため、フラッシュメッセージごとに部分テンプレートを作成しています。
→出品時以外でトップページに表示されてしまう意図しないフラッシュメッセージの表示は
renderとredirect_toの挙動に違いがあるみたいなのでrenderに修正しました。
→ログイン時に表示されなくなりました！
https://gyazo.com/d81239af760e5f2395a29f604fb31269

* 出品中の商品と売却済の商品の表示を修正しました。
https://gyazo.com/d1ff63877f8a2b26fa4a3d07d293a417

* 出品・編集時の画像アップロードの文言を修正しました。
https://gyazo.com/f31f4b5d79c2bc7108b38a7e3389af47

* SP用ヘッダーのログインボタンのレイアウトを修正しました
https://gyazo.com/c1d28b2aefc93f8a0c35c993eba12d1a
